### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: |
+          pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ panel = ["panel","bokeh-jupyter","ipympl","plotly","openpyxl"]
 [tool.setuptools.package-data]
 ionique = ["LLM_GUIDE.md", "llms.txt"]
 
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-* cp313-*"
+skip = "*-musllinux_*"
+before-build = "pip install numpy Cython"
+
 [tool.setuptools_scm]
 write_to = "src/ionique/_version.py"
 # fall back version is for downloading git repo


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — triggered on `v*` tags, builds wheels (cibuildwheel across ubuntu/macos/windows) and sdist, then publishes to PyPI via Trusted Publisher (OIDC)
- Adds `[tool.cibuildwheel]` config to `pyproject.toml` targeting CPython 3.10–3.13, skipping musllinux

## Pre-merge checklist
- [x] `release` environment created in GitHub repo settings
- [x] Trusted Publisher configured on PyPI (owner: `wanunulab`, repo: `ionique`, workflow: `publish.yml`, environment: `release`)

## After merge
- Tag and push: `git tag v0.4.0 && git push origin v0.4.0`
- Verify: `pip install ionique==0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)